### PR TITLE
Remove lesspipe related configuration

### DIFF
--- a/zsh/conf.d/00-environment.zsh
+++ b/zsh/conf.d/00-environment.zsh
@@ -17,7 +17,6 @@ export CXXFLAGS=" -O3 -march=native "
 
 export LESSHISTFILE=-
 export LESS="-R -S -# 4"
-export LESSOPEN="|lesspipe.sh %s"
 
 export GOPATH=~/.go
 


### PR DESCRIPTION
Remove configuration related to lesspipe. It just gets in the way and helps less
than it proposes itself to. It's better to keep less simple (isn't that why it's
called less? `less` is `more` something like that) while using (neo)vim when you
want syntax highlighting and some other niceties.
