### PR TITLE
Remove deprecated mosh function

### DIFF
--- a/zsh/conf.d/01-functions.zsh
+++ b/zsh/conf.d/01-functions.zsh
@@ -1,18 +1,1 @@
-# mosh
-#
-# Relays its arguments to mosh, but if it finds its first argument in one of set
-# values, it will execute 'tmuxinator start master' upon connection. It's here
-# as a shortcut to access the 'master' session on tmux every time I connect to
-# one of my servers.
-#
-# TODO: Move the server list to an environment variable.
 
-mosh() {
-  local servers=( akita odroid tokyo inaba )
-
-  if ((servers[(Ie)$1])); then
-    command mosh "$@" -- tmuxinator start master
-  else
-    command mosh "$@"
-  fi
-}


### PR DESCRIPTION
There's no real need for this function anymore. Manual intervention on servers
is discouraged, and I don't really intend to have many things on tmux sessions
running on the machines I manage.
