### PR TITLE
Remove hardcoded libva driver name

### DIFF
--- a/zsh/conf.d/00-environment.zsh
+++ b/zsh/conf.d/00-environment.zsh
@@ -24,7 +24,6 @@ export _JAVA_AWT_WM_NONREPARENTING=1
 export _JAVA_OPTIONS='-Dawt.useSystemAAFontSettings=lcd -Dswing.aatext=true'
 
 export MOSH_ESCAPE_KEY='~'
-export LIBVA_DRIVER_NAME=i965
 
 export ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=7'
 


### PR DESCRIPTION
For some reason, in the past I needed to hardcode the libva driver name to i965
so my Intel integrated graphics chip could be used for hardware acceleration
through VA-API.

Now that I'm primarily using different machines and this can be set per machine
rather easily, this is being removed. It's getting in the way of using other UHD
for hardware acceleration, after all.
