### PR TITLE
Use fzfmenu for prompts in XMonad

### DIFF
--- a/xmonad/lib/Config/Bindings.hs
+++ b/xmonad/lib/Config/Bindings.hs
@@ -24,8 +24,8 @@ keyBindings =
   , ("M-k", focusUp)
   , ("M-<R>", moveTo Next (WSIs . return $ (/= "NSP") . W.tag))
   , ("M-<L>", moveTo Prev (WSIs . return $ (/= "NSP") . W.tag))
-  , ("M-y", selectWorkspace)
-  , ("M-u", renameWorkspace)
+  , ("M-y", selectWorkspace' "fzfmenu" fzfmenuArgs)
+  , ("M-u", renameWorkspace' "fzfmenu" fzfmenuArgs)
   , ("M-i", removeWorkspace)
   , ("M-M1-h", withFocused hideWindow)
   , ("M-M1-j", withFocused swapWithNextHidden)
@@ -35,7 +35,7 @@ keyBindings =
   , ("M-s v", namedScratchpadAction MH.scratchpads "volume")
   , ("M-C-y", chooseWorkspace >>= windows . copy)
   , ("M-<Backspace>", kill1)
-  , ("M-S-y", withFocused moveToWorkspace)
+  , ("M-S-y", withFocused $ moveToWorkspace' "fzfmenu" fzfmenuArgs)
   , ("M-M1-c", withFocused $ keysMoveWindowTo (681,392) (1/2,1/2))
   ] ++ [ ("M-" ++ show n, withNthWorkspace' notNSP W.greedyView (n - 1))
          | n <- [1..9] ]
@@ -56,3 +56,5 @@ mouseBindings = [((mod4Mask, button3), (\w -> focus w >> mouseResizeWindow w))]
 
 notNSP :: [WorkspaceId] -> [WorkspaceId]
 notNSP = filter (/= "NSP")
+
+fzfmenuArgs = [ "--print-query", "--reverse", "+m" ]

--- a/xmonad/lib/XMonad/Actions/DmenuWorkspaces.hs
+++ b/xmonad/lib/XMonad/Actions/DmenuWorkspaces.hs
@@ -1,9 +1,13 @@
 module XMonad.Actions.DmenuWorkspaces
   ( selectWorkspace
+  , selectWorkspace'
   , moveToWorkspace
+  , moveToWorkspace'
   , renameWorkspace
+  , renameWorkspace'
   , removeWorkspace
   , chooseWorkspace
+  , chooseWorkspace'
   ) where
 
 import XMonad hiding (workspaces)
@@ -36,20 +40,32 @@ sendTo wn ws = do
 selectWorkspace :: X ()
 selectWorkspace = chooseWorkspace >>= goTo
 
+selectWorkspace' :: String -> [String] -> X ()
+selectWorkspace' cmd args = chooseWorkspace' cmd args >>= goTo
+
 -- | Creates a dmenu prompt with workspace names and returns the chosen name.
 chooseWorkspace :: X String
 chooseWorkspace = workspaceDmenu
+
+chooseWorkspace' :: String -> [String] -> X String
+chooseWorkspace' = workspaceMenuArgs
 
 -- | Prompts the user through dmenu and moves the given window to the chosen
 -- workspace.
 moveToWorkspace :: Window -> X ()
 moveToWorkspace = (chooseWorkspace >>=) . sendTo
 
+moveToWorkspace' :: String -> [String] -> Window -> X ()
+moveToWorkspace' cmd args w = chooseWorkspace' cmd args >>= sendTo w
+
 -- | Renames the current workspace by prompting the user through dmenu for a new
 -- workspace tag. No entries are given, as renaming should not be picked from a
 -- list of already used tags.
 renameWorkspace :: X ()
 renameWorkspace = dmenuArgs [] [] >>= renameWorkspaceByName
+
+renameWorkspace' :: String -> [String] -> X ()
+renameWorkspace' cmd args = menuArgs' cmd args [] >>= renameWorkspaceByName
 
 -- | Manually updates the current workspace tag in the WindowSet with a given
 -- string.

--- a/xmonad/lib/XMonad/Util/DmenuPrompts.hs
+++ b/xmonad/lib/XMonad/Util/DmenuPrompts.hs
@@ -13,8 +13,8 @@ import System.IO
 import System.Process (runInteractiveProcess)
 import Control.Monad (when)
 
-runProcessWithInput :: MonadIO m => FilePath -> [String] -> String -> m String
-runProcessWithInput cmd args input = io $ do
+getLastLineFromProcess :: MonadIO m => FilePath -> [String] -> String -> m String
+getLastLineFromProcess cmd args input = io $ do
   (pin, pout, perr, _) <- runInteractiveProcess cmd args Nothing Nothing
   hPutStr pin input
   hClose pin
@@ -22,11 +22,11 @@ runProcessWithInput cmd args input = io $ do
   when (output == output) $ return ()
   hClose pout
   hClose perr
-  return output
+  return $ last (lines output)
 
 menuArgs' :: String -> [String] -> [String] -> X String
 menuArgs' mcmd args opts = fmap (filter (/= '\n')) $
-  runProcessWithInput mcmd args (unlines opts)
+  getLastLineFromProcess mcmd args (unlines opts)
 
 dmenuArgs :: [String] -> [String] -> X String
 dmenuArgs = menuArgs' "dmenu"


### PR DESCRIPTION
Use fzfmenu in place of dmenu for prompts. Only possible using patched version
of st, since without the `override_redirect` bit set, XMonad's event loop will
hang and it'll stop responding.

The code in this pull request is rather dirty and pends refactoring. An issue
will be created for that. The support for menus can be generalized, provided the
prompting menus people try out set the `override_redirect` bit when mapping
their windows, or have no window at all.
