### PR TITLE
Fix autocmd that adds to Neovim's formatoptions

### DIFF
--- a/neovim/lua/autocommands.lua
+++ b/neovim/lua/autocommands.lua
@@ -24,8 +24,8 @@ autocmd({ "BufWritePost" }, {
 })
 
 autocmd({ "FileType" }, {
-  desc = "Autoformat paragraphs when editing Markdown.",
+  desc = "Autoformat paragraphs when editing Markdown or commit messages.",
   command = "set formatoptions+=a",
-  pattern = "markdown",
+  pattern = "markdown,gitcommit",
   group = "common"
 })

--- a/neovim/lua/autocommands.lua
+++ b/neovim/lua/autocommands.lua
@@ -23,8 +23,9 @@ autocmd({ "BufWritePost" }, {
   group = "common"
 })
 
-autocmd({ "FileType markdown" }, {
+autocmd({ "FileType" }, {
   desc = "Autoformat paragraphs when editing Markdown.",
-  callback = function () vim.bo.formatoptions = vim.bo.formatoptions .. "a" end,
+  command = "set formatoptions+=a",
+  pattern = "markdown",
   group = "common"
 })


### PR DESCRIPTION
Fix the issue of Neovim enabling paragraph autoformatting for every file by
correctly creating the autocommand, using `FileType` for the event and using
`markdown` as a pattern. Maybe it makes more sense for people who understand
VimL.

Additionally, enable paragraph autoformatting for Git commit messages.

Fixes #19.
