### PR TITLE
Ignore Neovim Packer's plugin directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /xmonad/build-x86_64-linux/
 /xmonad/xmonad-x86_64-linux
 /xmonad/xmonad.errors
+/neovim/plugin/


### PR DESCRIPTION
This directory will be created by Packer with a "compiled" Lua script. Ignore
it, since it is generated at every PackerSync and shouldn't be versioned.
