### PR TITLE
Make XMonad config into Stack project & add CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request: {}
+  push:
+    branches: [ master ]
+
+jobs:
+  xmonad:
+    name: XMonad
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout files in the repository
+        uses: actions/checkout@v3
+
+      - name: Setup Haskell & Stack
+        uses: haskell/actions/setup@v2
+        with:
+          enable-stack: true
+          stack-version: latest
+
+      - name: Build custom XMonad config
+        run: cd xmonad && stack build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
           enable-stack: true
           stack-version: latest
 
-      - name: Install required header files
-        run: sudo apt-get install -y libxrandr-dev
+      - name: Install XMonad C build dependencies
+        run: sudo apt-get install -y libx11-dev libxft-dev libxinerama-dev libxrandr-dev libxss-dev
 
       - name: Build custom XMonad config
         run: cd xmonad && stack build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,5 +19,8 @@ jobs:
           enable-stack: true
           stack-version: latest
 
+      - name: Install required header files
+        run: sudo apt-get install -y libxrandr-dev
+
       - name: Build custom XMonad config
         run: cd xmonad && stack build

--- a/xmonad/custom-xmonad.cabal
+++ b/xmonad/custom-xmonad.cabal
@@ -1,0 +1,37 @@
+name:       custom-xmonad
+version:    0.1.0
+license:    WTFPL
+author:     d3adb5
+maintainer: me@d3adb5.net
+
+build-type:    Simple
+cabal-version: >=1.10
+
+executable xmonad
+  main-is: ../xmonad.hs
+  hs-source-dirs: lib
+
+  build-depends: base
+               , containers
+               , data-default
+               , process
+               , xmonad >= 0.17
+               , xmonad-contrib >= 0.17
+
+  other-modules: Config.Bindings
+               , Config.Dimensions
+               , Config.HandleEventHook
+               , Config.Layouts
+               , Config.LogHook
+               , Config.ManageHook
+               , Config.StartupHook
+               , XMonad.Actions.DmenuWorkspaces
+               , XMonad.Actions.Hidden
+               , XMonad.Layout.Hidden
+               , XMonad.Layout.HiddenQueueLayout
+               , XMonad.Util.CenterRationalRect
+               , XMonad.Util.DmenuPrompts
+               , XMonad.Util.Hidden
+
+  default-language: Haskell2010
+  ghc-options: -Wall -threaded -j

--- a/xmonad/custom-xmonad.cabal
+++ b/xmonad/custom-xmonad.cabal
@@ -29,6 +29,7 @@ executable xmonad
                , XMonad.Actions.Hidden
                , XMonad.Layout.Hidden
                , XMonad.Layout.HiddenQueueLayout
+               , XMonad.Layout.VoidBorders
                , XMonad.Util.CenterRationalRect
                , XMonad.Util.DmenuPrompts
                , XMonad.Util.Hidden

--- a/xmonad/lib/XMonad/Layout/VoidBorders.hs
+++ b/xmonad/lib/XMonad/Layout/VoidBorders.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  XMonad.Layout.VoidBorders
+-- Description :  Set borders to 0 for all windows in the workspace.
+-- Copyright   :  Wilson Sales <spoonm@spoonm.org>
+-- License     :  BSD-style (see LICENSE)
+--
+-- Maintainer  :  <spoonm@spoonm.org>
+-- Stability   :  unstable
+-- Portability :  unportable
+--
+-- Modifies a layout to set borders to 0 for all windows in the workspace.
+--
+-- Unlike "XMonad.Layout.NoBorders", the 'voidBorders' modifier will not
+-- restore the window border if the windows are moved to a different workspace
+-- or the layout is changed. There is, however, a companion 'normalBorders'
+-- modifier which explicitly restores the border.
+--
+-- This modifier's primary use is to eliminate the "border flash" you get
+-- while switching workspaces with the "XMonad.Layout.NoBorders" modifier.
+--
+-----------------------------------------------------------------------------
+
+module XMonad.Layout.VoidBorders ( -- * Usage
+                                   -- $usage
+                                   voidBorders
+                                 , normalBorders
+                                 ) where
+
+import XMonad
+import XMonad.Layout.LayoutModifier
+import XMonad.StackSet (integrate)
+
+-- $usage
+-- You can use this module with the following in your ~\/.xmonad/xmonad.hs
+-- file:
+--
+-- > import XMonad.Layout.VoidBorders
+--
+-- and modify the layouts to call 'voidBorders' on the layouts you want to
+-- remove borders from windows, and 'normalBorders' on the layouts you want
+-- to keep borders for:
+--
+-- > layoutHook = ... ||| voidBorders Full ||| normalBorders Tall ...
+--
+-- For more detailed instructions on editing the layoutHook see:
+--
+-- "XMonad.Doc.Extending#Editing_the_layout_hook"
+
+data VoidBorders a = VoidBorders deriving (Read, Show)
+
+instance LayoutModifier VoidBorders Window where
+  modifierDescription = const "VoidBorders"
+
+  redoLayout VoidBorders _ Nothing wrs = return (wrs, Nothing)
+  redoLayout VoidBorders _ (Just s) wrs = do
+    mapM_ setZeroBorder $ integrate s
+    return (wrs, Nothing)
+
+voidBorders :: l Window -> ModifiedLayout VoidBorders l Window
+voidBorders = ModifiedLayout VoidBorders
+
+data NormalBorders a = NormalBorders deriving (Read, Show)
+
+instance LayoutModifier NormalBorders Window where
+  modifierDescription = const "NormalBorders"
+
+  redoLayout NormalBorders _ Nothing wrs = return (wrs, Nothing)
+  redoLayout NormalBorders _ (Just s) wrs = do
+    mapM_ resetBorders $ integrate s
+    return (wrs, Nothing)
+
+normalBorders :: l Window -> ModifiedLayout NormalBorders l Window
+normalBorders = ModifiedLayout NormalBorders
+
+-- | Sets border width to 0 for every window from the specified layout.
+setZeroBorder :: Window -> X ()
+setZeroBorder w = setBorders w 0
+
+-- | Resets the border to the value read from the current configuration.
+resetBorders :: Window -> X ()
+resetBorders w = asks (borderWidth . config) >>= setBorders w
+
+setBorders :: Window -> Dimension -> X ()
+setBorders w bw = withDisplay $ \d -> io $ setWindowBorderWidth d w bw

--- a/xmonad/stack.yaml
+++ b/xmonad/stack.yaml
@@ -1,0 +1,3 @@
+resolver: lts-19.6
+packages:
+  - "."


### PR DESCRIPTION
Make my XMonad configuration into a Stack project, so it can be built with a
simple `stack build`, once Stack is installed.

Since it's not possible to point to the latest "git" version of `xmonad-contrib`
or `xmonad`, a dependency was resolved by copying a module from upstream into
this repository temporarily. X.L.VoidBorders was copied in 5c46ae7.

Additionally, since the build process is now simplified, a CI workflow was added
to automatically build the XMonad config with each PR.

Closes #22.
