### PR TITLE
Set Neovim's default fold level to 3

### DIFF
--- a/neovim/lua/settings.lua
+++ b/neovim/lua/settings.lua
@@ -25,6 +25,9 @@ global.sidescrolloff = 5
 global.completeopt = "menu,menuone,noinsert,noselect"
 global.shortmess   = "filnxtToOFc"
 
+global.foldlevelstart = 3
+window.foldlevel = 3
+
 window.list       = true
 window.number     = true
 window.cursorline = true


### PR DESCRIPTION
This makes it so only folds at a level higher than 3 are closed by default.
Folds are useful when there's plenty of content, but if there is structure in a
small file, they tend to just get in the way.
