### PR TITLE
Enable Haskell & Lua language servers

### DIFF
--- a/neovim/lua/completion.lua
+++ b/neovim/lua/completion.lua
@@ -15,3 +15,5 @@ cmp.setup({
 lsp.groovyls.setup({ capabilities = cap })
 lsp.pyright.setup({ capabilities = cap })
 lsp.terraformls.setup({ capabilities = cap })
+lsp.hls.setup({ capabilities = cap })
+lsp.sumneko_lua.setup({ capabilities = cap })


### PR DESCRIPTION
Enable the Haskell Language Server and sumneko_lua langauge servers, configured through vim-lsp.
