### PR TITLE
Force icon size in stalonetray to prevent mismatches

### DIFF
--- a/stalonetray/stalonetrayrc
+++ b/stalonetray/stalonetrayrc
@@ -13,6 +13,8 @@ parent_bg   false
 grow_gravity SE
 icon_gravity NE
 
+kludges force_icons_size
+
 skip_taskbar true
 sticky       true
 vertical     false


### PR DESCRIPTION
Force the icon size in stalonetray so that programs like Steam that cause problems with abnormous icon sizes despite 'icon_size 16' will no longer mess the tray area up and demand a restart of stalonetray.
