### PR TITLE
Update Neovim configuration

### DIFF
--- a/neovim/init.lua
+++ b/neovim/init.lua
@@ -105,6 +105,12 @@ require("packer").startup(function ()
   -- {{{ completion, linting, language servers
   use "mfussenegger/nvim-lint"
 
+  use { "github/copilot.vim",
+    config = function ()
+      vim.g.copilot_filetypes = { markdown = true }
+    end
+  }
+
   use { "hrsh7th/nvim-cmp",
     after = "nvim-lspconfig",
     requires = {

--- a/neovim/init.lua
+++ b/neovim/init.lua
@@ -122,23 +122,6 @@ require("packer").startup(function ()
     config = function () require("completion") end
   }
 
-  use { "neovim/nvim-lspconfig",
-    config = function ()
-      vim.keymap.set("n", "K",     vim.lsp.buf.hover)
-      vim.keymap.set("n", "gd",    vim.lsp.buf.definition)
-      vim.keymap.set("n", "gi",    vim.lsp.buf.implementation)
-      vim.keymap.set("n", "gr",    vim.lsp.buf.references)
-      vim.keymap.set("n", "gD",    vim.lsp.buf.declaration)
-      vim.keymap.set("n", "<C-s>", vim.lsp.buf.signature_help)
-
-      vim.keymap.set("n", "<leader>f",  vim.lsp.buf.formatting)
-      vim.keymap.set("n", "<leader>D",  vim.lsp.buf.type_definition)
-      vim.keymap.set("n", "<leader>rn", vim.lsp.buf.rename)
-      vim.keymap.set("n", "<leader>ca", vim.lsp.buf.code_action)
-
-      vim.keymap.set("n", "<C-k>", vim.lsp.diagnostic.goto_prev)
-      vim.keymap.set("n", "<C-j>", vim.lsp.diagnostic.goto_next)
-    end
-  }
+  use "neovim/nvim-lspconfig"
   -- }}}
 end)

--- a/neovim/init.lua
+++ b/neovim/init.lua
@@ -46,7 +46,7 @@ require("packer").startup(function ()
   -- }}}
   -- {{{ additional highlighting and convenience
   use { "lilydjwg/colorizer",     ft = {"markdown", "html", "scss", "css"} }
-  use { "preservim/vim-markdown", ft = "markdown" }
+  use { "tpope/vim-markdown",     ft = "markdown" }
   use { "dkarter/bullets.vim",    ft = "markdown" }
   use { "junegunn/goyo.vim",      ft = "markdown" }
   use { "hashivim/vim-terraform", ft = "terraform" }

--- a/neovim/lua/autocommands.lua
+++ b/neovim/lua/autocommands.lua
@@ -29,3 +29,10 @@ autocmd({ "FileType" }, {
   pattern = "markdown,gitcommit",
   group = "common"
 })
+
+autocmd({ "FileType" }, {
+  desc = "Set expandtab and tab width when editing Haskell code.",
+  command = "set et ts=2 sw=2",
+  pattern = "haskell",
+  group = "common"
+})

--- a/neovim/lua/completion.lua
+++ b/neovim/lua/completion.lua
@@ -1,7 +1,21 @@
 local cmp = require("cmp")
 local lsp = require("lspconfig")
-local cap = require("cmp_nvim_lsp")
-  .update_capabilities(vim.lsp.protocol.make_client_capabilities())
+local cap = require("cmp_nvim_lsp").default_capabilities()
+
+local on_attach = function (client, bufnr)
+  local bufopts = { noremap = true, silent = true, buffer = bufnr }
+  vim.keymap.set("n", "K",     vim.lsp.buf.hover, bufopts)
+  vim.keymap.set("n", "gd",    vim.lsp.buf.definition, bufopts)
+  vim.keymap.set("n", "gi",    vim.lsp.buf.implementation, bufopts)
+  vim.keymap.set("n", "gr",    vim.lsp.buf.references, bufopts)
+  vim.keymap.set("n", "gD",    vim.lsp.buf.declaration, bufopts)
+  vim.keymap.set("n", "<C-s>", vim.lsp.buf.signature_help, bufopts)
+
+  vim.keymap.set("n", "<leader>f",  vim.lsp.buf.formatting, bufopts)
+  vim.keymap.set("n", "<leader>D",  vim.lsp.buf.type_definition, bufopts)
+  vim.keymap.set("n", "<leader>rn", vim.lsp.buf.rename, bufopts)
+  vim.keymap.set("n", "<leader>ca", vim.lsp.buf.code_action, bufopts)
+end
 
 cmp.setup({
   snippet = { expand = function (a) vim.fn["UltiSnips#Anon"](a.body) end },
@@ -12,8 +26,8 @@ cmp.setup({
   }
 })
 
-lsp.groovyls.setup({ capabilities = cap })
-lsp.pyright.setup({ capabilities = cap })
-lsp.terraformls.setup({ capabilities = cap })
-lsp.hls.setup({ capabilities = cap })
-lsp.sumneko_lua.setup({ capabilities = cap })
+lsp.groovyls.setup({ on_attach = on_attach, capabilities = cap })
+lsp.pyright.setup({ on_attach = on_attach, capabilities = cap })
+lsp.terraformls.setup({ on_attach = on_attach, capabilities = cap })
+lsp.hls.setup({ on_attach = on_attach, capabilities = cap })
+lsp.sumneko_lua.setup({ on_attach = on_attach, capabilities = cap })

--- a/neovim/lua/highlights.lua
+++ b/neovim/lua/highlights.lua
@@ -4,6 +4,7 @@ end
 
 hl("CursorLine",   { ctermbg =  0 })
 hl("CursorLineNr", { ctermfg = 11, ctermbg = 0})
+hl("NormalFloat",  {})
 hl("Pmenu",        { ctermfg =  7, ctermbg = 0 })
 hl("PmenuSel",     { ctermfg = 15, ctermbg = 8 })
 hl("Todo",         { ctermfg = 15, ctermbg = 7 })

--- a/neovim/lua/mappings.lua
+++ b/neovim/lua/mappings.lua
@@ -5,3 +5,6 @@ map("t", "<Esc>", "<C-\\><C-n>")
 
 map("n", "'", "`")
 map("n", "`", "'")
+
+map("n", "<C-k>", vim.diagnostic.goto_prev)
+map("n", "<C-j>", vim.diagnostic.goto_next)


### PR DESCRIPTION
Cumulative Neovim configuration update. Summary as a list of commits:

- feat(nvim): switch to tpope's markdown plugin
- feat(nvim): add github copilot to config
- chore(nvim): set up lsp keybinds only on load
- feat(nvim): set et ts=2 sw=2 for haskell files
- chore(nvim): clear default style for NormalFloat
