### PR TITLE
CI: Cache dependencies across builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,22 @@ jobs:
           stack-version: latest
           stack-no-global: true
 
+      - uses: actions/cache@v3
+        name: Cache ~/.stack
+        with:
+          path: ~/.stack
+          key: stack-global-${{ hashFiles('xmonad/stack.yaml') }}
+          restore-keys: |
+            stack-global-
+
+      - name: Cache .stack-work
+        uses: actions/cache@v3
+        with:
+          path: xmonad/.stack-work
+          key: stack-work-${{ hashFiles('xmonad/stack.yaml') }}-${{ hashFiles('**/*.hs') }}
+          restore-keys: |
+            stack-work-
+
       - name: Install XMonad C build dependencies
         run: sudo apt-get install -y libx11-dev libxft-dev libxinerama-dev libxrandr-dev libxss-dev
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           enable-stack: true
           stack-version: latest
+          stack-no-global: true
 
       - name: Install XMonad C build dependencies
         run: sudo apt-get install -y libx11-dev libxft-dev libxinerama-dev libxrandr-dev libxss-dev


### PR DESCRIPTION
Cache dependencies for XMonad across builds, to prevent runs from taking longer to execute than they need to.
