### PR TITLE
Zathura: disable GUI elements by default

### DIFF
--- a/zathura/zathurarc
+++ b/zathura/zathurarc
@@ -1,0 +1,1 @@
+set guioptions none


### PR DESCRIPTION
Disable the GUI elements --- more specifically the status bar that comes enabled by default --- in Zathura's resource config.
