### PR TITLE
fix(firefox): decrease top margin a furhter 2px

### DIFF
--- a/firefox/userChrome.css
+++ b/firefox/userChrome.css
@@ -81,7 +81,7 @@
 }
 
 :root:not([customizing]) #navigator-toolbox {
-  margin-top: -39px;
+  margin-top: -41px;
   transition: 100ms;
 }
 


### PR DESCRIPTION
Decrease the top margin a further 2 pixels, since with some new updates, Firefox had a lingering 2px shadow that made it so moving the cursor at the top of the window was constantly triggering the slide-out for the navigation bar.
