### PR TITLE
feat(zsh): use running ssh-agent socket

### DIFF
--- a/systemd/ssh-agent.service
+++ b/systemd/ssh-agent.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=SSH key agent
+
+[Service]
+Type=simple
+Environment=SSH_AUTH_SOCK=%t/ssh-agent.socket
+ExecStart=/usr/bin/ssh-agent -t 5m -D -a $SSH_AUTH_SOCK
+
+[Install]
+WantedBy=default.target

--- a/zsh/conf.d/00-environment.zsh
+++ b/zsh/conf.d/00-environment.zsh
@@ -2,6 +2,8 @@ export HISTFILE="$HOME/.zsh_history"
 export HISTSIZE=500000
 export SAVEHIST=1000000
 
+export SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/ssh-agent.socket"
+
 export EDITOR=nvim
 export BROWSER=firefox
 export NO_AT_BRIDGE=1


### PR DESCRIPTION
Add a systemd unit for running ssh-agent upon login, and export `SSH_AUTH_SOCK` to instances of zsh so that ssh may use it.
