### PR TITLE
xmonad: remove workspaces through keybind only when empty

### DIFF
--- a/xmonad/lib/Config/Bindings.hs
+++ b/xmonad/lib/Config/Bindings.hs
@@ -26,7 +26,7 @@ keyBindings =
   , ("M-<L>", moveTo Prev (WSIs . return $ (/= "NSP") . W.tag))
   , ("M-y", selectWorkspace' "fzfmenu" fzfmenuArgs)
   , ("M-u", renameWorkspace' "fzfmenu" fzfmenuArgs)
-  , ("M-i", removeWorkspace)
+  , ("M-i", removeWorkspaceIfEmpty)
   , ("M-M1-h", withFocused hideWindow)
   , ("M-M1-j", withFocused swapWithNextHidden)
   , ("M-M1-k", withFocused swapWithLastHidden)

--- a/xmonad/lib/XMonad/Actions/DmenuWorkspaces.hs
+++ b/xmonad/lib/XMonad/Actions/DmenuWorkspaces.hs
@@ -6,6 +6,8 @@ module XMonad.Actions.DmenuWorkspaces
   , renameWorkspace
   , renameWorkspace'
   , removeWorkspace
+  , removeWorkspaceIfEmpty
+  , removeWorkspaceWhen
   , chooseWorkspace
   , chooseWorkspace'
   ) where
@@ -16,6 +18,7 @@ import qualified XMonad.Actions.DynamicWorkspaces as DW
 import XMonad.Util.DmenuPrompts
 import XMonad.Actions.DynamicWorkspaceOrder (getSortByOrder, updateName, removeName)
 
+import Control.Monad (when)
 import Data.Maybe
 
 -- | Switches to a workspace given its tag. Will create it if it doesn't exist.
@@ -101,8 +104,15 @@ removeWorkspace' wsp wset = rmWkspc xs ys
       }
     rmWkspc _ _ = wset
 
+removeWorkspaceWhen :: (WindowSpace -> Bool) -> X ()
+removeWorkspaceWhen pred = do
+  ws <- gets $ workspace . current . windowset
+  when (pred ws) $ do
+    DW.removeWorkspace
+    removeName $ tag ws
+
+removeWorkspaceIfEmpty :: X ()
+removeWorkspaceIfEmpty = removeWorkspaceWhen (null . integrate' . stack)
+
 removeWorkspace :: X ()
-removeWorkspace = do
-  tag <- gets (currentTag . windowset)
-  DW.removeWorkspace
-  removeName tag
+removeWorkspace = removeWorkspaceWhen (const True)


### PR DESCRIPTION
Add actions to conditionally remove workspaces and change keybind so that they're only removed if they're empty.
