### PR TITLE
feat(nvim): enable linting for markdown w/vale

### DIFF
--- a/neovim/lua/linting.lua
+++ b/neovim/lua/linting.lua
@@ -1,0 +1,5 @@
+local lint = require 'lint'
+
+lint.linters_by_ft = {
+  markdown = {'vale'}
+}


### PR DESCRIPTION
Configure nvim-lint to use Vale for linting markdown files.
