### PR TITLE
feat(zsh): make backward-kill-word stop at slashes

### DIFF
--- a/zsh/conf.d/00-environment.zsh
+++ b/zsh/conf.d/00-environment.zsh
@@ -29,6 +29,9 @@ export MOSH_ESCAPE_KEY='~'
 
 export ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=7'
 
+# Makes sure '/' is not considered part of words for backward-kill-word.
+export WORDCHARS="${WORDCHARS/\/}"
+
 path+=(
 	"$HOME/.local/bin"
 	"$HOME/.cabal/bin"


### PR DESCRIPTION
Make it so the backward-kill-word command stops at slashes by removing it from the list of additional word characters (WORDCHARS).
