### PR TITLE
xmonad: fix warnings with minor refactoring

### DIFF
--- a/xmonad/lib/Config/Bindings.hs
+++ b/xmonad/lib/Config/Bindings.hs
@@ -55,4 +55,5 @@ mouseBindings = [((mod4Mask, button3), (\w -> focus w >> mouseResizeWindow w))]
 notNSP :: [WorkspaceId] -> [WorkspaceId]
 notNSP = filter (/= "NSP")
 
+fzfmenuArgs :: [String]
 fzfmenuArgs = [ "--print-query", "--reverse", "+m" ]

--- a/xmonad/lib/Config/Bindings.hs
+++ b/xmonad/lib/Config/Bindings.hs
@@ -15,8 +15,6 @@ import XMonad.Util.NamedScratchpad
 import qualified Config.ManageHook as MH
 import qualified XMonad.StackSet as W
 
-import Data.Default
-
 keyBindings :: [(String, X ())]
 keyBindings =
   [ ("M-]", spawn =<< fmap (terminal . config) ask)

--- a/xmonad/lib/Config/Dimensions.hs
+++ b/xmonad/lib/Config/Dimensions.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wno-missing-signatures -Wno-type-defaults #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
 
 module Config.Dimensions where

--- a/xmonad/lib/Config/Dimensions.hs
+++ b/xmonad/lib/Config/Dimensions.hs
@@ -32,8 +32,8 @@ terminalCRatio columns = horizontalSpan % availableHorizontalSpan
 -- | Calculates the vertical ratio of a terminal window given the number of
 -- lines it should have.
 terminalLRatio :: Integral a => a -> Ratio a
-terminalLRatio lines = verticalSpan % availableVerticalSpan
-  where verticalSpan = lines * characterHeight + 2 * commonGap
+terminalLRatio lnum = verticalSpan % availableVerticalSpan
+  where verticalSpan = lnum * characterHeight + 2 * commonGap
 
 -- | Calculates the horizontal ratio of a window given its width in pixels.
 horizontalRatio :: Integral a => a -> Ratio a

--- a/xmonad/lib/Config/Layouts.hs
+++ b/xmonad/lib/Config/Layouts.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wno-missing-signatures #-}
 module Config.Layouts (layoutHook) where
 
 import XMonad (Full(..), (|||))

--- a/xmonad/lib/Config/LogHook.hs
+++ b/xmonad/lib/Config/LogHook.hs
@@ -4,7 +4,7 @@ import XMonad hiding (logHook)
 import XMonad.Actions.Hidden (unhideOnFocus)
 import XMonad.Actions.UpdatePointer
 import XMonad.Hooks.DynamicLog
-import XMonad.Util.Hidden (withHidden, getHidden)
+import XMonad.Util.Hidden (withHidden)
 import XMonad.Util.SpawnNamedPipe
 
 import qualified XMonad.StackSet as W

--- a/xmonad/lib/Config/LogHook.hs
+++ b/xmonad/lib/Config/LogHook.hs
@@ -27,8 +27,7 @@ barPP = def
   }
   where
     hiddenNum = withHidden $ return . catchZero . length
-    catchZero = \l -> if l == 0 then Nothing else Just $ replicate l '―'
-    toIcon = wrap "<icon=.local/share/icons/xpm/" ".xpm/>"
+    catchZero l = if l == 0 then Nothing else Just $ replicate l '―'
 
 logHook :: X ()
 logHook = do
@@ -40,17 +39,17 @@ logHook = do
   dynamicLogWithPP $
     barPP { ppOutput = hPutStrLn xmobarHandle . centerField . words }
   where
-    centerField [a] = a
-    centerField [a,b] = printf "%s %s %s" b a b
+    centerField [] = error "centerField: empty list"
+    centerField (x:xs) = printf "%s %s %s" (concat xs) x (concat xs)
 
 avoidWorkspaces :: [WorkspaceId] -> X ()
 avoidWorkspaces wss = withWorkspace $ \ws ->
-  when ((W.tag ws) `elem` wss) $
+  when (W.tag ws `elem` wss) $
     DO.withNthWorkspace' (filter (`notElem` wss)) W.greedyView 0
 
 removeWhenEmpty :: [WorkspaceId] -> X ()
 removeWhenEmpty wss = withWorkspace $ \ws ->
-  when (isNothing (W.stack ws) && (W.tag ws) `elem` wss) $
+  when (isNothing (W.stack ws) && W.tag ws `elem` wss) $
     DW.removeWorkspaceByTag $ W.tag ws
 
 withWorkspace :: (WindowSpace -> X a) -> X a

--- a/xmonad/lib/Config/LogHook.hs
+++ b/xmonad/lib/Config/LogHook.hs
@@ -53,4 +53,5 @@ removeWhenEmpty wss = withWorkspace $ \ws ->
   when (isNothing (W.stack ws) && (W.tag ws) `elem` wss) $
     DW.removeWorkspaceByTag $ W.tag ws
 
+withWorkspace :: (WindowSpace -> X a) -> X a
 withWorkspace = (gets (W.workspace . W.current . windowset) >>=)

--- a/xmonad/lib/Config/ManageHook.hs
+++ b/xmonad/lib/Config/ManageHook.hs
@@ -5,7 +5,7 @@ import XMonad hiding (manageHook, borderWidth)
 import XMonad.Hooks.InsertPosition
 import XMonad.Hooks.ManageHelpers
 import XMonad.Util.CenterRationalRect
-import XMonad.Util.NamedScratchpad
+import XMonad.Util.NamedScratchpad hiding (hook)
 import XMonad.Util.WindowProperties (getProp32s)
 import XMonad.StackSet (floating)
 

--- a/xmonad/lib/Config/ManageHook.hs
+++ b/xmonad/lib/Config/ManageHook.hs
@@ -1,4 +1,4 @@
-{-# OPTIONS_GHC -Wno-type-defaults #-}
+{-# OPTIONS_GHC -Wno-type-defaults -Wno-unused-top-binds #-}
 module Config.ManageHook (manageHook, scratchpads) where
 
 import XMonad hiding (manageHook, borderWidth)

--- a/xmonad/lib/Config/ManageHook.hs
+++ b/xmonad/lib/Config/ManageHook.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wno-type-defaults #-}
 module Config.ManageHook (manageHook, scratchpads) where
 
 import XMonad hiding (manageHook, borderWidth)

--- a/xmonad/lib/XMonad/Actions/DmenuWorkspaces.hs
+++ b/xmonad/lib/XMonad/Actions/DmenuWorkspaces.hs
@@ -16,7 +16,7 @@ import XMonad hiding (workspaces)
 import XMonad.StackSet hiding (filter)
 import qualified XMonad.Actions.DynamicWorkspaces as DW
 import XMonad.Util.DmenuPrompts
-import XMonad.Actions.DynamicWorkspaceOrder (getSortByOrder, updateName, removeName)
+import XMonad.Actions.DynamicWorkspaceOrder (updateName, removeName)
 
 import Control.Monad (when)
 import Data.Maybe

--- a/xmonad/lib/XMonad/Actions/DmenuWorkspaces.hs
+++ b/xmonad/lib/XMonad/Actions/DmenuWorkspaces.hs
@@ -19,6 +19,7 @@ import XMonad.Util.DmenuPrompts
 import XMonad.Actions.DynamicWorkspaceOrder (updateName, removeName)
 
 import Control.Monad (when)
+import Data.List (find)
 import Data.Maybe
 
 -- | Switches to a workspace given its tag. Will create it if it doesn't exist.
@@ -65,49 +66,49 @@ moveToWorkspace' cmd args w = chooseWorkspace' cmd args >>= sendTo w
 -- workspace tag. No entries are given, as renaming should not be picked from a
 -- list of already used tags.
 renameWorkspace :: X ()
-renameWorkspace = dmenuArgs [] [] >>= renameWorkspaceByName
+renameWorkspace = dmenuArgs [] [] >>= renameCurrentWorkspace
 
 renameWorkspace' :: String -> [String] -> X ()
-renameWorkspace' cmd args = menuArgs' cmd args [] >>= renameWorkspaceByName
+renameWorkspace' cmd args = menuArgs' cmd args [] >>= renameCurrentWorkspace
 
 -- | Manually updates the current workspace tag in the WindowSet with a given
 -- string.
 setCurrentTag :: WorkspaceId -> WindowSet -> WindowSet
-setCurrentTag tag =
-  let setTag wk = wk { tag = tag }
+setCurrentTag newTag =
+  let setTag wk = wk { tag = newTag }
       setWsp sc = sc { workspace = setTag (workspace sc) }
       setScr ws = ws { current = setWsp (current ws) }
   in setScr
 
-renameWorkspaceByName :: WorkspaceId -> X ()
-renameWorkspaceByName "" = return ()
-renameWorkspaceByName ws = do
+-- | Sets the current workspace's tag to the given string. If another workspace
+-- already exists with the desired name, that workspace will be removed and its
+-- windows will be brought to the current workspace's stack.
+renameCurrentWorkspace :: WorkspaceId -> X ()
+renameCurrentWorkspace "" = return ()
+renameCurrentWorkspace ws = do
   gets (currentTag . windowset) >>= flip updateName ws
-  windows $ setCurrentTag ws . removeWorkspace' ws
+  windows $ setCurrentTag ws . removeWorkspaceWithoutRefresh ws
 
-removeWorkspace' :: WorkspaceId -> WindowSet -> WindowSet
-removeWorkspace' wsp wset = rmWkspc xs ys
-  where
-    (xs, ys) = break ((== wsp) . tag) (hidden wset)
+removeWorkspaceWithoutRefresh :: WorkspaceId -> WindowSet -> WindowSet
+removeWorkspaceWithoutRefresh name wset = newWindowSet
+  where foundWorkspace = find ((== name) . tag) $ hidden wset
+        currentScreen = current wset
+        currentWorkspace = workspace currentScreen
+        meld (Just x) (Just y) = differentiate $ integrate x ++ integrate y
+        meld a b | isNothing a = b
+                 | otherwise = a
 
-    meld (Just x) (Just y) = differentiate $ integrate x ++ integrate y
-    meld a b | isNothing a = b
-             | otherwise = a
+        newStack | isNothing foundWorkspace = stack currentWorkspace
+                 | otherwise = meld (stack $ fromJust foundWorkspace) (stack currentWorkspace)
 
-    rmWkspc xs (y:ys) = wset
-      { current = (current wset)
-        { workspace = (workspace $ current wset)
-          { stack = meld (stack y) (stack . workspace $ current wset)
-          }
-        }
-      , hidden = xs ++ ys
-      }
-    rmWkspc _ _ = wset
+        newWindowSet =
+          wset { hidden = filter ((/= name) . tag) $ hidden wset
+               , current = currentScreen { workspace = currentWorkspace { stack = newStack } } }
 
 removeWorkspaceWhen :: (WindowSpace -> Bool) -> X ()
-removeWorkspaceWhen pred = do
+removeWorkspaceWhen predicate = do
   ws <- gets $ workspace . current . windowset
-  when (pred ws) $ do
+  when (predicate ws) $ do
     DW.removeWorkspace
     removeName $ tag ws
 

--- a/xmonad/lib/XMonad/Actions/Hidden.hs
+++ b/xmonad/lib/XMonad/Actions/Hidden.hs
@@ -61,10 +61,10 @@ swapWithNextHidden :: Window -> X ()
 swapWithNextHidden w = withNextHidden $ flip (swapWithHidden w) (flip (S.|>))
 
 withLastHidden :: (Window -> X a) -> X a
-withLastHidden = withHidden . (\f -> f . rightmost)
+withLastHidden = withHidden . (. rightmost)
 
 withNextHidden :: (Window -> X a) -> X a
-withNextHidden = withHidden . (\f -> f . leftmost)
+withNextHidden = withHidden . (. leftmost)
 
 unhideOnFocus :: X ()
 unhideOnFocus = withFocused $ \fwin ->
@@ -74,10 +74,10 @@ unhideOnFocus = withFocused $ \fwin ->
 -- these shall fail if the sequence is empty, but we expect that never to happen
 leftmost  :: (Eq a) => S.Seq a -> a
 rightmost :: (Eq a) => S.Seq a -> a
-leftmost seq  | (l S.:< _) <- S.viewl seq = l
-              | otherwise = error "empty sequence"
-rightmost seq | (_ S.:> r) <- S.viewr seq = r
-              | otherwise = error "empty sequence"
+leftmost s  | (l S.:< _) <- S.viewl s = l
+            | otherwise = error "empty sequence"
+rightmost s | (_ S.:> r) <- S.viewr s = r
+            | otherwise = error "empty sequence"
 
 -- this won't fail at all, but yeah, I just needed a delete
 delete :: (Eq a) => a -> S.Seq a -> S.Seq a

--- a/xmonad/lib/XMonad/Layout/Hidden.hs
+++ b/xmonad/lib/XMonad/Layout/Hidden.hs
@@ -39,9 +39,9 @@ instance LayoutModifier HiddenL Window where
 
   handleMess HiddenL m
     | Just BW.UpdateBoring <- fromMessage m = do
-        hidden <- XS.gets hiddenWindows
+        hiddenW <- XS.gets hiddenWindows
         ws <- XMonad.gets (W.workspace . W.current . windowset)
-        flip sendMessageWithNoRefresh ws $ BW.Replace "Hidden" (toList hidden)
+        flip sendMessageWithNoRefresh ws $ BW.Replace "Hidden" (toList hiddenW)
         return Nothing
     | otherwise = return Nothing
 
@@ -50,15 +50,15 @@ instance LayoutModifier HideNAt Window where
 
   modifyLayout (HideNAt n at) wksp rect = do
     let visibleWindows = W.integrate' (W.stack wksp)
-    hiddenWindows <- getHidden
+    hiddenW <- getHidden
 
     let willHideWindow = length visibleWindows > at
-        willUnhideWindow = length hiddenWindows > 1 && length visibleWindows < at
+        willUnhideWindow = length hiddenW > 1 && length visibleWindows < at
         stackToBeTiled | willHideWindow = deleteNthElem n (W.stack wksp)
-                       | willUnhideWindow = prepend (rightmost hiddenWindows) (W.stack wksp)
+                       | willUnhideWindow = prepend (rightmost hiddenW) (W.stack wksp)
                        | otherwise = W.stack wksp
 
-    when willUnhideWindow $ unhideWindowAndAct (rightmost hiddenWindows) (pure ())
+    when willUnhideWindow $ unhideWindowAndAct (rightmost hiddenW) (pure ())
     when willHideWindow $ hideWindowAndAct (<|) (visibleWindows !! (n - 1)) (pure ())
     runLayout (wksp { W.stack = stackToBeTiled }) rect
 

--- a/xmonad/lib/XMonad/Layout/Hidden.hs
+++ b/xmonad/lib/XMonad/Layout/Hidden.hs
@@ -18,7 +18,6 @@ import qualified XMonad.Layout.BoringWindows as BW
 
 import Control.Monad (when)
 import Data.Foldable (toList)
-import Data.List (splitAt)
 import Data.Sequence ((<|))
 
 data HiddenL a = HiddenL         deriving (Read, Show)

--- a/xmonad/lib/XMonad/Layout/Hidden.hs
+++ b/xmonad/lib/XMonad/Layout/Hidden.hs
@@ -26,6 +26,7 @@ data HideNAt a = HideNAt Int Int deriving (Read, Show)
 hidden :: l Window -> ModifiedLayout HiddenL l Window
 hidden = ModifiedLayout HiddenL
 
+hideNAt :: Int -> Int -> l Window -> ModifiedLayout HiddenL (ModifiedLayout HideNAt l) Window
 hideNAt n at = hidden . ModifiedLayout (HideNAt n at)
 
 instance LayoutModifier HiddenL Window where

--- a/xmonad/lib/XMonad/Layout/HiddenQueueLayout.hs
+++ b/xmonad/lib/XMonad/Layout/HiddenQueueLayout.hs
@@ -11,7 +11,7 @@ module XMonad.Layout.HiddenQueueLayout
 
 import XMonad hiding (tile, focus)
 import XMonad.Actions.Hidden
-import XMonad.StackSet hiding (visible, delete)
+import XMonad.StackSet hiding (visible, delete, stack, hidden)
 import XMonad.Util.Hidden
 
 import qualified XMonad.StackSet as W

--- a/xmonad/lib/XMonad/Layout/HiddenQueueLayout.hs
+++ b/xmonad/lib/XMonad/Layout/HiddenQueueLayout.hs
@@ -28,9 +28,8 @@ data HiddenQueueLayout a = HQLayout
   } deriving (Show, Read)
 
 instance LayoutClass HiddenQueueLayout Window where
-  doLayout l@(HQLayout swn mr sr _) rect stack = do
+  doLayout (HQLayout swn mr sr _) rect stack = do
     hidden <- getHidden
-    fcswin <- gets (W.peek . windowset)
     let viswin = visible stack hidden
         shouldHide = length viswin > swn + 1
         shouldUnhide = hidden /= S.empty && length viswin < swn + 1
@@ -44,7 +43,7 @@ instance LayoutClass HiddenQueueLayout Window where
       unhideWindowAndAct toUnhide (pure ())
     return . (, Nothing) . ap zip (tile swn mr sr rect . length) $ tiled'
 
-  handleMessage lyt@(HQLayout swnum mratio stratio rratio) msg =
+  handleMessage lyt@(HQLayout swnum mratio _ rratio) msg =
     return $ msum
       [ fmap resize (fromMessage msg)
       , fmap incsid (fromMessage msg)
@@ -63,7 +62,7 @@ tile 1 m _ r n = drop (2 - n) [r1,r2] where (r1,r2) = splitHorizontallyBy m r
 tile 2 m t r n = drop (3 - n) [r1,r2,r3]
   where (r1,rs) = splitHorizontallyBy m r
         (r2,r3) = splitVerticallyBy t rs
-tile n m _ r w = drop (length (r1:rss) - w) (r1:rss)
+tile _ m _ r w = drop (length (r1:rss) - w) (r1:rss)
   where (r1,rs) = splitHorizontallyBy m r
         rss = splitVertically (w - 1) rs
 
@@ -74,5 +73,5 @@ visible s h = integrate' $ W.filter (`notElem` h) s
 -- | Deletes an element of a list given its index.
 delete :: Int -> [a] -> [a]
 delete _ [] = []
-delete 0 (x:xs) = xs
+delete 0 (_:xs) = xs
 delete i (x:xs) = x : delete (i - 1) xs

--- a/xmonad/lib/XMonad/Layout/HiddenQueueLayout.hs
+++ b/xmonad/lib/XMonad/Layout/HiddenQueueLayout.hs
@@ -15,7 +15,6 @@ import XMonad.StackSet hiding (visible, delete)
 import XMonad.Util.Hidden
 
 import qualified XMonad.StackSet as W
-import qualified XMonad.Util.ExtensibleState as XS
 
 import Control.Monad (ap, msum, when)
 import Data.Sequence (Seq(..), (<|))

--- a/xmonad/lib/XMonad/Util/Hidden.hs
+++ b/xmonad/lib/XMonad/Util/Hidden.hs
@@ -18,7 +18,7 @@ module XMonad.Util.Hidden
   , withHidden
   ) where
 
-import XMonad
+import XMonad hiding (display, state)
 import qualified XMonad.StackSet as W
 import qualified XMonad.Util.ExtensibleState as XS
 import XMonad.Util.WindowProperties (getProp32)

--- a/xmonad/lib/XMonad/Util/Hidden.hs
+++ b/xmonad/lib/XMonad/Util/Hidden.hs
@@ -23,7 +23,6 @@ import qualified XMonad.StackSet as W
 import qualified XMonad.Util.ExtensibleState as XS
 import XMonad.Util.WindowProperties (getProp32)
 
-import qualified Data.Map as M
 import Data.Maybe (fromMaybe)
 import qualified Data.List as L
 import qualified Data.Sequence as S


### PR DESCRIPTION
Refactor a bit of code in order to eliminate all warnings. Some warnings have been ignore for specific modules, so that they can either be addressed later or be forever ignored.
