### PR TITLE
chore(nvim): invoke linter only after writing file

### DIFF
--- a/neovim/lua/autocommands.lua
+++ b/neovim/lua/autocommands.lua
@@ -18,8 +18,8 @@ autocmd({ "BufEnter", "BufWritePost" }, {
   group = "common"
 })
 
-autocmd({ "TextChangedI", "TextChanged" }, {
-  desc = "Attempt linting when changes were made to the text.",
+autocmd({ "BufWritePost" }, {
+  desc = "Attempt linting when files are written.",
   callback = function () lint.try_lint() end,
   group = "common"
 })


### PR DESCRIPTION
Attempt linting only after writing the current file. This way we are not bombarding the CPU with linting processes that end up waiting to write their results to the current buffer.
