### PR TITLE
chore(tray): ignore fcitx tray window on stalonetray

### DIFF
--- a/stalonetray/stalonetrayrc
+++ b/stalonetray/stalonetrayrc
@@ -23,3 +23,5 @@ window_layer normal
 window_strut auto
 window_type  dock
 xsync        false
+
+ignore_classes fcitx


### PR DESCRIPTION
Have stalonetray ignore the fcitx5 tray window.
