### PR TITLE
chore(nvim): run makeprg silently through autocmd

### DIFF
--- a/neovim/lua/autocommands.lua
+++ b/neovim/lua/autocommands.lua
@@ -26,7 +26,7 @@ autocmd({ "BufWritePost" }, {
 
 autocmd({ "BufWritePost" }, {
   desc = "Run the 'make' program if it's set to something other than 'make'.",
-  command = "if &makeprg != 'make' | make | endif",
+  command = "if &makeprg != 'make' | silent make | endif",
   group = "common"
 })
 


### PR DESCRIPTION
If running makeprg through the autocommand on BufWrite, run it silently since most of the time we're not preoccupied with the output.
