### PR TITLE
feat(tmux): set window title to include session name

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -1,6 +1,8 @@
 set -g default-terminal "tmux-256color"
 set -g -a terminal-overrides ',*:Se=\E[4 q'
 set -g allow-rename off
+set -g set-titles on
+set -g set-titles-string "tmux session: #S"
 set -g escape-time 0
 
 set -g mode-keys vi

--- a/xmonad/lib/Config/ManageHook.hs
+++ b/xmonad/lib/Config/ManageHook.hs
@@ -42,7 +42,7 @@ manageHook = composeAll
 scratchpads :: [NamedScratchpad]
 scratchpads =
   [ NS "term" "st -n scratch -t scratch -e tmux new -A -s scratch"
-    (title =? "scratch")
+    (appName =? "scratch")
     (customFloating $ centerIRectOffsetY panelHeight tw th sw sh)
   , NS "volume" "pavucontrol"
     (className =? "Pavucontrol")


### PR DESCRIPTION
Change the terminal emulator window title to include the tmux session name in addition to a reference to tmux. This makes it easier to identify terminal windows by the tmux session that it is attached to.

The XMonad configuration was changed to use the application name to identify the terminal named scratchpad, as the window title is no longer unique.
