### PR TITLE
feat(xmonad): add keybind to search for windows

### DIFF
--- a/xmonad/lib/Config/Bindings.hs
+++ b/xmonad/lib/Config/Bindings.hs
@@ -10,6 +10,7 @@ import XMonad.Actions.FloatKeys (keysMoveWindowTo)
 import XMonad.Actions.Hidden
 import XMonad.Actions.PhysicalScreens
 import XMonad.Layout.BoringWindows (focusDown, focusUp)
+import XMonad.Util.DmenuPrompts (windowsMenu)
 import XMonad.Util.NamedScratchpad
 
 import qualified Config.ManageHook as MH
@@ -22,6 +23,7 @@ keyBindings =
   , ("M-k", focusUp)
   , ("M-<R>", moveTo Next (WSIs . return $ (/= "NSP") . W.tag))
   , ("M-<L>", moveTo Prev (WSIs . return $ (/= "NSP") . W.tag))
+  , ("M-a", windowsMenu "fzfmenu" >>= windows . W.focusWindow)
   , ("M-y", selectWorkspace' "fzfmenu" fzfmenuArgs)
   , ("M-u", renameWorkspace' "fzfmenu" fzfmenuArgs)
   , ("M-i", removeWorkspaceIfEmpty)

--- a/xmonad/lib/XMonad/Util/DmenuPrompts.hs
+++ b/xmonad/lib/XMonad/Util/DmenuPrompts.hs
@@ -6,12 +6,12 @@
 module XMonad.Util.DmenuPrompts where
 
 import XMonad hiding (workspaces)
-import XMonad.StackSet (workspaces, tag)
+import XMonad.StackSet (workspaces, allWindows, tag)
 import XMonad.Actions.DynamicWorkspaceOrder (getSortByOrder)
 
 import System.IO
 import System.Process (runInteractiveProcess)
-import Control.Monad (when)
+import Control.Monad (when, liftM2)
 
 getLastLineFromProcess :: MonadIO m => FilePath -> [String] -> String -> m String
 getLastLineFromProcess cmd args input = io $ do
@@ -31,11 +31,22 @@ menuArgs' mcmd args opts = filter (/= '\n') <$>
 dmenuArgs :: [String] -> [String] -> X String
 dmenuArgs = menuArgs' "dmenu"
 
+windowsMenuArgs :: String -> [String] -> X Window
+windowsMenuArgs m a = do
+  ws <- gets (allWindows . windowset)
+  options <- mapM (\w -> concat' (show w) <$> prettyPrint w) ws
+  read . takeWhile (/= ' ') <$> menuArgs' m a options
+  where concat' s1 s2 = s1 ++ " - " ++ s2
+        prettyPrint w = liftM2 concat' (runQuery appName w) (runQuery title w)
+
 workspaceMenuArgs :: String -> [String] -> X String
 workspaceMenuArgs m a = do
   ws <- gets (workspaces . windowset)
   sort <- getSortByOrder
   menuArgs' m a . filter (/= "NSP") . map tag $ sort ws
+
+windowsMenu :: String -> X Window
+windowsMenu = flip windowsMenuArgs []
 
 workspaceMenu :: String -> X String
 workspaceMenu = flip workspaceMenuArgs []


### PR DESCRIPTION
Add a keybind and utilitary functions to pipe all window IDs, titles, and application names to a menu (such as dmenu or fzfmenu) and allow the user to select one to focus on any workspace.
