### PR TITLE
fix(nvim): use vim.lsp.buf.format instead .formatting

### DIFF
--- a/neovim/lua/completion.lua
+++ b/neovim/lua/completion.lua
@@ -11,7 +11,7 @@ local on_attach = function (client, bufnr)
   vim.keymap.set("n", "gD",    vim.lsp.buf.declaration, bufopts)
   vim.keymap.set("n", "<C-s>", vim.lsp.buf.signature_help, bufopts)
 
-  vim.keymap.set("n", "<leader>f",  vim.lsp.buf.formatting, bufopts)
+  vim.keymap.set("n", "<leader>f",  vim.lsp.buf.format, bufopts)
   vim.keymap.set("n", "<leader>D",  vim.lsp.buf.type_definition, bufopts)
   vim.keymap.set("n", "<leader>rn", vim.lsp.buf.rename, bufopts)
   vim.keymap.set("n", "<leader>ca", vim.lsp.buf.code_action, bufopts)


### PR DESCRIPTION
There is longer a vim.lsp.buf.formatting, so it has been replaced with vim.lsp.buf.format.
