### PR TITLE
chore(xmonad): add class to window menu options

### DIFF
--- a/xmonad/src/XMonad/Util/DmenuPrompts.hs
+++ b/xmonad/src/XMonad/Util/DmenuPrompts.hs
@@ -3,7 +3,16 @@
 -- and refuse to use it instead of the good ol' dmenu.
 --------------------------------------------------------------------------------
 
-module XMonad.Util.DmenuPrompts where
+module XMonad.Util.DmenuPrompts
+  ( menuArgs'
+  , dmenuArgs
+  , windowsMenuArgs
+  , windowsMenu
+  , workspaceMenuArgs
+  , workspaceMenu
+  , workspaceDmenuArgs
+  , workspaceDmenu
+  ) where
 
 import XMonad hiding (workspaces)
 import XMonad.StackSet (workspaces, allWindows, tag)
@@ -11,7 +20,9 @@ import XMonad.Actions.DynamicWorkspaceOrder (getSortByOrder)
 
 import System.IO
 import System.Process (runInteractiveProcess)
-import Control.Monad (when, liftM2)
+import Control.Monad (when)
+import Data.Char (toUpper)
+import Data.List.Split (splitOneOf)
 
 getLastLineFromProcess :: MonadIO m => FilePath -> [String] -> String -> m String
 getLastLineFromProcess cmd args input = io $ do
@@ -34,10 +45,23 @@ dmenuArgs = menuArgs' "dmenu"
 windowsMenuArgs :: String -> [String] -> X Window
 windowsMenuArgs m a = do
   ws <- gets (allWindows . windowset)
-  options <- mapM (\w -> concat' (show w) <$> prettyPrint w) ws
+  options <- mapM windowPrettyPrint ws
   read . takeWhile (/= ' ') <$> menuArgs' m a options
-  where concat' s1 s2 = s1 ++ " - " ++ s2
-        prettyPrint w = liftM2 concat' (runQuery appName w) (runQuery title w)
+
+-- Lambda lifted way to turn a Window into a String for menu indexing.
+windowPrettyPrint :: Window -> X String
+windowPrettyPrint w = foldl optionConcat (show w) <$> mapM (`runQuery` w) windowQueries
+
+-- Lambda lifted way to concatenate two strings into a menu option.
+optionConcat :: String -> String -> String
+optionConcat s1 s2 = s1 ++ " • " ++ s2
+
+-- List of queries to run for a Window when listing it as a menu option.
+windowQueries :: [Query String]
+windowQueries = [titlefy <$> className, titlefy <$> appName, title]
+  where titlefy = unwords . map capitalize . splitOneOf " -_"
+        capitalize (h:t) = toUpper h : t
+        capitalize [] = []
 
 workspaceMenuArgs :: String -> [String] -> X String
 workspaceMenuArgs m a = do

--- a/xmonad/xmonad-d3adb5.cabal
+++ b/xmonad/xmonad-d3adb5.cabal
@@ -15,6 +15,7 @@ executable xmonad
                , containers
                , data-default
                , process
+               , split
                , xmonad >= 0.17
                , xmonad-contrib >= 0.17
 


### PR DESCRIPTION
Add the window class name to the options listed in the windows menu when picking a window to focus on through fzfmenu / dmenu. This change also involves lambda lifting a few functions, restricting the symbols exported by the module, and changing the delimiter for option fields.
