### PR TITLE
feat: set default fzf command to find all but .git/*

### DIFF
--- a/zsh/conf.d/00-environment.zsh
+++ b/zsh/conf.d/00-environment.zsh
@@ -29,6 +29,8 @@ export MOSH_ESCAPE_KEY='~'
 
 export ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=7'
 
+export FZF_DEFAULT_COMMAND="find . -type f -not -path '*/\.git/*'"
+
 # Makes sure '/' is not considered part of words for backward-kill-word.
 export WORDCHARS="${WORDCHARS/\/}"
 


### PR DESCRIPTION
Set default fzf command to a find invocation that includes any hidden files except for those under '.git'. This allows me to easily reach files in .github through fzf.vim's :Files command.
